### PR TITLE
Skip empty attributes to translate.

### DIFF
--- a/genshi/filters/i18n.py
+++ b/genshi/filters/i18n.py
@@ -711,8 +711,9 @@ class Translator(DirectiveFactory):
                 for name, value in attrs:
                     newval = value
                     if isinstance(value, six.string_types):
-                        if translate_attrs and name in include_attrs and value:
-                            newval = gettext(value)
+                        text = value.strip()
+                        if translate_attrs and name in include_attrs and text:
+                            newval = gettext(text)
                     else:
                         newval = list(
                             self(_ensure(value), ctxt, translate_text=False)

--- a/genshi/filters/i18n.py
+++ b/genshi/filters/i18n.py
@@ -711,7 +711,7 @@ class Translator(DirectiveFactory):
                 for name, value in attrs:
                     newval = value
                     if isinstance(value, six.string_types):
-                        if translate_attrs and name in include_attrs:
+                        if translate_attrs and name in include_attrs and value:
                             newval = gettext(value)
                     else:
                         newval = list(

--- a/genshi/filters/tests/i18n.py
+++ b/genshi/filters/tests/i18n.py
@@ -105,6 +105,14 @@ class TranslatorTestCase(unittest.TestCase):
         kind, data, pos = stream[2]
         assert isinstance(data[1], Attrs)
 
+    def test_extract_included_empty_attribute_text(self):
+        tmpl = MarkupTemplate(u"""<html>
+          <span title="">...</span>
+        </html>""")
+        translator = Translator()
+        messages = list(translator.extract(tmpl.stream))
+        self.assertEqual([], messages)
+
     def test_translate_included_empty_attribute_text(self):
         tmpl = MarkupTemplate(u"""<html>
           <span title="">...</span>
@@ -225,6 +233,25 @@ class TranslatorTestCase(unittest.TestCase):
         translator.setup(tmpl)
         self.assertEqual("""<html>
           <p>Voh</p>
+        </html>""", tmpl.generate().render())
+
+    def test_extract_included_attribute_text_with_spaces(self):
+        tmpl = MarkupTemplate("""<html xmlns:py="http://genshi.edgewall.org/">
+          <span title=" Foo ">...</span>
+        </html>""")
+        translator = Translator()
+        messages = list(translator.extract(tmpl.stream))
+        self.assertEqual(1, len(messages))
+        self.assertEqual((2, None, 'Foo', []), messages[0])
+
+    def test_translate_included_attribute_text_with_spaces(self):
+        tmpl = MarkupTemplate("""<html xmlns:py="http://genshi.edgewall.org/">
+          <span title=" Foo ">...</span>
+        </html>""")
+        translator = Translator(DummyTranslations({'Foo': 'Voh'}))
+        translator.setup(tmpl)
+        self.assertEqual("""<html>
+          <span title="Voh">...</span>
         </html>""", tmpl.generate().render())
 
 

--- a/genshi/filters/tests/i18n.py
+++ b/genshi/filters/tests/i18n.py
@@ -105,6 +105,16 @@ class TranslatorTestCase(unittest.TestCase):
         kind, data, pos = stream[2]
         assert isinstance(data[1], Attrs)
 
+    def test_translate_included_empty_attribute_text(self):
+        tmpl = MarkupTemplate(u"""<html>
+          <span title="">...</span>
+        </html>""")
+        translator = Translator(DummyTranslations({'': 'Project-Id-Version'}))
+        translator.setup(tmpl)
+        self.assertEqual("""<html>
+          <span title="">...</span>
+        </html>""", tmpl.generate().render())
+
     def test_extract_without_text(self):
         tmpl = MarkupTemplate("""<html xmlns:py="http://genshi.edgewall.org/">
           <p title="Bar">Foo</p>


### PR DESCRIPTION
I encountered that Genshi generates placeholder with *.po header for empty placeholder like this:

```xml
<input type="text" placeholder="" />
```
to:
```xml
<input type="text" placeholder="Project-Id-Version: ..." />
```
Another example of empty `alt` attribute in https://trac.edgewall.org/ticket/10108#comment:2.

I think we should skip empty attributes to translate.