### PR TITLE
Replace deprecated assertEquals with assertEqual.

### DIFF
--- a/genshi/filters/tests/test_html.py
+++ b/genshi/filters/tests/test_html.py
@@ -27,7 +27,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="text" name="foo" />
         </p></form>""") | HTMLFormFiller()
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="text" name="foo"/>
         </p></form>""", html.render())
 
@@ -35,7 +35,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="text" name="foo" />
         </p></form>""") | HTMLFormFiller(data={'foo': 'bar'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="text" name="foo" value="bar"/>
         </p></form>""", html.render())
 
@@ -43,7 +43,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="text" name="foo" />
         </p></form>""") | HTMLFormFiller(data={'foo': ['bar']})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="text" name="foo" value="bar"/>
         </p></form>""", html.render())
 
@@ -51,7 +51,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="hidden" name="foo" />
         </p></form>""") | HTMLFormFiller()
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="hidden" name="foo"/>
         </p></form>""", html.render())
 
@@ -59,7 +59,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="hidden" name="foo" />
         </p></form>""") | HTMLFormFiller(data={'foo': 'bar'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="hidden" name="foo" value="bar"/>
         </p></form>""", html.render())
 
@@ -67,7 +67,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="hidden" name="foo" />
         </p></form>""") | HTMLFormFiller(data={'foo': ['bar']})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="hidden" name="foo" value="bar"/>
         </p></form>""", html.render())
 
@@ -75,7 +75,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <textarea name="foo"></textarea>
         </p></form>""") | HTMLFormFiller()
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <textarea name="foo"/>
         </p></form>""", html.render())
 
@@ -83,7 +83,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <textarea name="foo"></textarea>
         </p></form>""") | HTMLFormFiller(data={'foo': 'bar'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <textarea name="foo">bar</textarea>
         </p></form>""", html.render())
 
@@ -91,7 +91,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <textarea name="foo"></textarea>
         </p></form>""") | HTMLFormFiller(data={'foo': ['bar']})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <textarea name="foo">bar</textarea>
         </p></form>""", html.render())
 
@@ -102,7 +102,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
           <textarea name="foo"></textarea>
           <textarea name="bar"></textarea>
         </p></form>""") | HTMLFormFiller(data={'foo': 'Some text'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <textarea name="foo">Some text</textarea>
           <textarea name="bar"/>
         </p></form>""", html.render())
@@ -112,7 +112,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
           <textarea name="foo"></textarea>
           <textarea name="bar">Original value</textarea>
         </p></form>""") | HTMLFormFiller(data={'foo': 'Some text'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <textarea name="foo">Some text</textarea>
           <textarea name="bar">Original value</textarea>
         </p></form>""", html.render())
@@ -121,7 +121,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="checkbox" name="foo" />
         </p></form>""") | HTMLFormFiller()
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo"/>
         </p></form>""", html.render())
 
@@ -129,10 +129,10 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="checkbox" name="foo" />
         </p></form>""")
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ''})).render())
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': 'on'})).render())
 
@@ -140,10 +140,10 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML("""<form><p>
           <input type="checkbox" name="foo" value="1" />
         </p></form>""", encoding='ascii')
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo" value="1" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': '1'})).render())
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo" value="1"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': '2'})).render())
 
@@ -151,10 +151,10 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML("""<form><p>
           <input type="checkbox" name="foo" />
         </p></form>""", encoding='ascii')
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': []})).render())
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ['on']})).render())
 
@@ -162,10 +162,10 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="checkbox" name="foo" value="1" />
         </p></form>""")
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo" value="1" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ['1']})).render())
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="checkbox" name="foo" value="1"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ['2']})).render())
 
@@ -173,7 +173,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="radio" name="foo" />
         </p></form>""") | HTMLFormFiller()
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="radio" name="foo"/>
         </p></form>""", html.render())
 
@@ -181,10 +181,10 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="radio" name="foo" value="1" />
         </p></form>""")
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="radio" name="foo" value="1" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': '1'})).render())
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="radio" name="foo" value="1"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': '2'})).render())
 
@@ -192,10 +192,10 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="radio" name="foo" value="1" />
         </p></form>""")
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="radio" name="foo" value="1" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ['1']})).render())
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="radio" name="foo" value="1"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ['2']})).render())
 
@@ -203,7 +203,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="radio" name="foo" value="" />
         </p></form>""")
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="radio" name="foo" value="" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ''})).render())
 
@@ -211,7 +211,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="radio" name="foo" value="" />
         </p></form>""")
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="radio" name="foo" value="" checked="checked"/>
         </p></form>""", (html | HTMLFormFiller(data={'foo': ['']})).render())
 
@@ -223,7 +223,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option>3</option>
           </select>
         </p></form>""") | HTMLFormFiller()
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <select name="foo">
             <option>1</option>
             <option>2</option>
@@ -239,7 +239,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option value="3">3</option>
           </select>
         </p></form>""") | HTMLFormFiller()
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <select name="foo">
             <option value="1">1</option>
             <option value="2">2</option>
@@ -255,7 +255,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option>3</option>
           </select>
         </p></form>""") | HTMLFormFiller(data={'foo': '1'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <select name="foo">
             <option selected="selected">1</option>
             <option>2</option>
@@ -271,7 +271,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option value="3">3</option>
           </select>
         </p></form>""") | HTMLFormFiller(data={'foo': '1'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <select name="foo">
             <option value="1" selected="selected">1</option>
             <option value="2">2</option>
@@ -287,7 +287,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option>3</option>
           </select>
         </p></form>""") | HTMLFormFiller(data={'foo': ['1', '3']})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <select name="foo" multiple="multiple">
             <option selected="selected">1</option>
             <option>2</option>
@@ -303,7 +303,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option value="3">3</option>
           </select>
         </p></form>""") | HTMLFormFiller(data={'foo': ['1', '3']})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <select name="foo" multiple="multiple">
             <option value="1" selected="selected">1</option>
             <option value="2">2</option>
@@ -317,7 +317,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option value="1">foo $x</option>
           </select>
         </form>""").generate(x=1) | HTMLFormFiller(data={'foo': '1'})
-        self.assertEquals(u"""<form>
+        self.assertEqual(u"""<form>
           <select name="foo">
             <option value="1" selected="selected">foo 1</option>
           </select>
@@ -329,7 +329,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option>foo $x bar</option>
           </select>
         </form>""").generate(x=1) | HTMLFormFiller(data={'foo': 'foo 1 bar'})
-        self.assertEquals("""<form>
+        self.assertEqual("""<form>
           <select name="foo">
             <option selected="selected">foo 1 bar</option>
           </select>
@@ -341,7 +341,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
             <option value="&ouml;">foo</option>
           </select>
         </form>""") | HTMLFormFiller(data={'foo': u'ö'})
-        self.assertEquals(u"""<form>
+        self.assertEqual(u"""<form>
           <select name="foo">
             <option value="ö" selected="selected">foo</option>
           </select>
@@ -351,7 +351,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="password" name="pass" />
         </p></form>""") | HTMLFormFiller(data={'pass': 'bar'})
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="password" name="pass"/>
         </p></form>""", html.render())
 
@@ -359,7 +359,7 @@ class HTMLFormFillerTestCase(unittest.TestCase):
         html = HTML(u"""<form><p>
           <input type="password" name="pass" />
         </p></form>""") | HTMLFormFiller(data={'pass': '1234'}, passwords=True)
-        self.assertEquals("""<form><p>
+        self.assertEqual("""<form><p>
           <input type="password" name="pass" value="1234"/>
         </p></form>""", html.render())
 
@@ -380,48 +380,48 @@ class HTMLSanitizerTestCase(unittest.TestCase):
         sanitized_html = (html | HTMLSanitizer()).render()
         if not sanitized_html and allow_strip:
             return
-        self.assertEquals(expected, sanitized_html)
+        self.assertEqual(expected, sanitized_html)
 
     def test_sanitize_unchanged(self):
         html = HTML(u'<a href="#">fo<br />o</a>')
-        self.assertEquals('<a href="#">fo<br/>o</a>',
+        self.assertEqual('<a href="#">fo<br/>o</a>',
                           (html | HTMLSanitizer()).render())
         html = HTML(u'<a href="#with:colon">foo</a>')
-        self.assertEquals('<a href="#with:colon">foo</a>',
+        self.assertEqual('<a href="#with:colon">foo</a>',
                           (html | HTMLSanitizer()).render())
 
     def test_sanitize_escape_text(self):
         html = HTML(u'<a href="#">fo&amp;</a>')
-        self.assertEquals('<a href="#">fo&amp;</a>',
+        self.assertEqual('<a href="#">fo&amp;</a>',
                           (html | HTMLSanitizer()).render())
         html = HTML(u'<a href="#">&lt;foo&gt;</a>')
-        self.assertEquals('<a href="#">&lt;foo&gt;</a>',
+        self.assertEqual('<a href="#">&lt;foo&gt;</a>',
                           (html | HTMLSanitizer()).render())
 
     def test_sanitize_entityref_text(self):
         html = HTML(u'<a href="#">fo&ouml;</a>')
-        self.assertEquals(u'<a href="#">foö</a>',
+        self.assertEqual(u'<a href="#">foö</a>',
                           (html | HTMLSanitizer()).render(encoding=None))
 
     def test_sanitize_escape_attr(self):
         html = HTML(u'<div title="&lt;foo&gt;"></div>')
-        self.assertEquals('<div title="&lt;foo&gt;"/>',
+        self.assertEqual('<div title="&lt;foo&gt;"/>',
                           (html | HTMLSanitizer()).render())
 
     def test_sanitize_close_empty_tag(self):
         html = HTML(u'<a href="#">fo<br>o</a>')
-        self.assertEquals('<a href="#">fo<br/>o</a>',
+        self.assertEqual('<a href="#">fo<br/>o</a>',
                           (html | HTMLSanitizer()).render())
 
     def test_sanitize_invalid_entity(self):
         html = HTML(u'&junk;')
-        self.assertEquals('&amp;junk;', (html | HTMLSanitizer()).render())
+        self.assertEqual('&amp;junk;', (html | HTMLSanitizer()).render())
 
     def test_sanitize_remove_script_elem(self):
         html = HTML(u'<script>alert("Foo")</script>')
-        self.assertEquals('', (html | HTMLSanitizer()).render())
+        self.assertEqual('', (html | HTMLSanitizer()).render())
         html = HTML(u'<SCRIPT SRC="http://example.com/"></SCRIPT>')
-        self.assertEquals('', (html | HTMLSanitizer()).render())
+        self.assertEqual('', (html | HTMLSanitizer()).render())
         src = u'<SCR\0IPT>alert("foo")</SCR\0IPT>'
         self.assert_parse_error_or_equal('&lt;SCR\x00IPT&gt;alert("foo")', src,
                                          allow_strip=True)
@@ -432,96 +432,96 @@ class HTMLSanitizerTestCase(unittest.TestCase):
 
     def test_sanitize_remove_onclick_attr(self):
         html = HTML(u'<div onclick=\'alert("foo")\' />')
-        self.assertEquals('<div/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<div/>', (html | HTMLSanitizer()).render())
 
     def test_sanitize_remove_input_password(self):
         html = HTML(u'<form><input type="password" /></form>')
-        self.assertEquals('<form/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<form/>', (html | HTMLSanitizer()).render())
 
     def test_sanitize_remove_comments(self):
         html = HTML(u'''<div><!-- conditional comment crap --></div>''')
-        self.assertEquals('<div/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<div/>', (html | HTMLSanitizer()).render())
 
     def test_sanitize_remove_style_scripts(self):
         sanitizer = StyleSanitizer()
         # Inline style with url() using javascript: scheme
         html = HTML(u'<DIV STYLE=\'background: url(javascript:alert("foo"))\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         # Inline style with url() using javascript: scheme, using control char
         html = HTML(u'<DIV STYLE=\'background: url(&#1;javascript:alert("foo"))\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         # Inline style with url() using javascript: scheme, in quotes
         html = HTML(u'<DIV STYLE=\'background: url("javascript:alert(foo)")\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         # IE expressions in CSS not allowed
         html = HTML(u'<DIV STYLE=\'width: expression(alert("foo"));\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<DIV STYLE=\'width: e/**/xpression(alert("foo"));\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<DIV STYLE=\'background: url(javascript:alert("foo"));'
                                  'color: #fff\'>')
-        self.assertEquals('<div style="color: #fff"/>',
+        self.assertEqual('<div style="color: #fff"/>',
                           (html | sanitizer).render())
         # Inline style with url() using javascript: scheme, using unicode
         # escapes
         html = HTML(u'<DIV STYLE=\'background: \\75rl(javascript:alert("foo"))\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<DIV STYLE=\'background: \\000075rl(javascript:alert("foo"))\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<DIV STYLE=\'background: \\75 rl(javascript:alert("foo"))\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<DIV STYLE=\'background: \\000075 rl(javascript:alert("foo"))\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<DIV STYLE=\'background: \\000075\r\nrl(javascript:alert("foo"))\'>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
 
     def test_sanitize_remove_style_phishing(self):
         sanitizer = StyleSanitizer()
         # The position property is not allowed
         html = HTML(u'<div style="position:absolute;top:0"></div>')
-        self.assertEquals('<div style="top:0"/>', (html | sanitizer).render())
+        self.assertEqual('<div style="top:0"/>', (html | sanitizer).render())
         # Normal margins get passed through
         html = HTML(u'<div style="margin:10px 20px"></div>')
-        self.assertEquals('<div style="margin:10px 20px"/>',
+        self.assertEqual('<div style="margin:10px 20px"/>',
                           (html | sanitizer).render())
         # But not negative margins
         html = HTML(u'<div style="margin:-1000px 0 0"></div>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<div style="margin-left:-2000px 0 0"></div>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
         html = HTML(u'<div style="margin-left:1em 1em 1em -4000px"></div>')
-        self.assertEquals('<div/>', (html | sanitizer).render())
+        self.assertEqual('<div/>', (html | sanitizer).render())
 
     def test_sanitize_remove_src_javascript(self):
         html = HTML(u'<img src=\'javascript:alert("foo")\'>')
-        self.assertEquals('<img/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<img/>', (html | HTMLSanitizer()).render())
         # Case-insensitive protocol matching
         html = HTML(u'<IMG SRC=\'JaVaScRiPt:alert("foo")\'>')
-        self.assertEquals('<img/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<img/>', (html | HTMLSanitizer()).render())
         # Grave accents (not parsed)
         src = u'<IMG SRC=`javascript:alert("RSnake says, \'foo\'")`>'
         self.assert_parse_error_or_equal('<img/>', src)
         # Protocol encoded using UTF-8 numeric entities
         html = HTML(u'<IMG SRC=\'&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;'
                     '&#112;&#116;&#58;alert("foo")\'>')
-        self.assertEquals('<img/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<img/>', (html | HTMLSanitizer()).render())
         # Protocol encoded using UTF-8 numeric entities without a semicolon
         # (which is allowed because the max number of digits is used)
         html = HTML(u'<IMG SRC=\'&#0000106&#0000097&#0000118&#0000097'
                     '&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116'
                     '&#0000058alert("foo")\'>')
-        self.assertEquals('<img/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<img/>', (html | HTMLSanitizer()).render())
         # Protocol encoded using UTF-8 numeric hex entities without a semicolon
         # (which is allowed because the max number of digits is used)
         html = HTML(u'<IMG SRC=\'&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69'
                     '&#x70&#x74&#x3A;alert("foo")\'>')
-        self.assertEquals('<img/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<img/>', (html | HTMLSanitizer()).render())
         # Embedded tab character in protocol
         html = HTML(u'<IMG SRC=\'jav\tascript:alert("foo");\'>')
-        self.assertEquals('<img/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<img/>', (html | HTMLSanitizer()).render())
         # Embedded tab character in protocol, but encoded this time
         html = HTML(u'<IMG SRC=\'jav&#x09;ascript:alert("foo");\'>')
-        self.assertEquals('<img/>', (html | HTMLSanitizer()).render())
+        self.assertEqual('<img/>', (html | HTMLSanitizer()).render())
 
     def test_sanitize_expression(self):
         html = HTML(u'<div style="top:expression(alert())">XSS</div>')

--- a/genshi/tests/core.py
+++ b/genshi/tests/core.py
@@ -55,7 +55,7 @@ class StreamTestCase(unittest.TestCase):
         pickle.dump(xml, buf, 2)
         buf.seek(0)
         xml = pickle.load(buf)
-        self.assertEquals('<li>Foo</li>', xml.render(encoding=None))
+        self.assertEqual('<li>Foo</li>', xml.render(encoding=None))
 
 
 class MarkupTestCase(unittest.TestCase):
@@ -63,108 +63,108 @@ class MarkupTestCase(unittest.TestCase):
     def test_new_with_encoding(self):
         markup = Markup(u'Döner'.encode('utf-8'), encoding='utf-8')
         # mimic Markup.__repr__ when constructing output for Python 2/3 compatibility
-        self.assertEquals("<Markup %r>" % u'D\u00f6ner', repr(markup))
+        self.assertEqual("<Markup %r>" % u'D\u00f6ner', repr(markup))
 
     def test_repr(self):
         markup = Markup('foo')
         expected_foo = "u'foo'" if IS_PYTHON2 else "'foo'"
-        self.assertEquals("<Markup %s>" % expected_foo, repr(markup))
+        self.assertEqual("<Markup %s>" % expected_foo, repr(markup))
 
     def test_escape(self):
         markup = escape('<b>"&"</b>')
         assert type(markup) is Markup
-        self.assertEquals('&lt;b&gt;&#34;&amp;&#34;&lt;/b&gt;', markup)
+        self.assertEqual('&lt;b&gt;&#34;&amp;&#34;&lt;/b&gt;', markup)
 
     def test_escape_noquotes(self):
         markup = escape('<b>"&"</b>', quotes=False)
         assert type(markup) is Markup
-        self.assertEquals('&lt;b&gt;"&amp;"&lt;/b&gt;', markup)
+        self.assertEqual('&lt;b&gt;"&amp;"&lt;/b&gt;', markup)
 
     def test_unescape_markup(self):
         string = '<b>"&"</b>'
         markup = Markup.escape(string)
         assert type(markup) is Markup
-        self.assertEquals(string, unescape(markup))
+        self.assertEqual(string, unescape(markup))
 
     def test_Markup_escape_None_noquotes(self):
         markup = Markup.escape(None, False)
         assert type(markup) is Markup
-        self.assertEquals('', markup)
+        self.assertEqual('', markup)
 
     def test_add_str(self):
         markup = Markup('<b>foo</b>') + '<br/>'
         assert type(markup) is Markup
-        self.assertEquals('<b>foo</b>&lt;br/&gt;', markup)
+        self.assertEqual('<b>foo</b>&lt;br/&gt;', markup)
 
     def test_add_markup(self):
         markup = Markup('<b>foo</b>') + Markup('<br/>')
         assert type(markup) is Markup
-        self.assertEquals('<b>foo</b><br/>', markup)
+        self.assertEqual('<b>foo</b><br/>', markup)
 
     def test_add_reverse(self):
         markup = '<br/>' + Markup('<b>bar</b>')
         assert type(markup) is Markup
-        self.assertEquals('&lt;br/&gt;<b>bar</b>', markup)
+        self.assertEqual('&lt;br/&gt;<b>bar</b>', markup)
 
     def test_mod(self):
         markup = Markup('<b>%s</b>') % '&'
         assert type(markup) is Markup
-        self.assertEquals('<b>&amp;</b>', markup)
+        self.assertEqual('<b>&amp;</b>', markup)
 
     def test_mod_multi(self):
         markup = Markup('<b>%s</b> %s') % ('&', 'boo')
         assert type(markup) is Markup
-        self.assertEquals('<b>&amp;</b> boo', markup)
+        self.assertEqual('<b>&amp;</b> boo', markup)
 
     def test_mod_mapping(self):
         markup = Markup('<b>%(foo)s</b>') % {'foo': '&'}
         assert type(markup) is Markup
-        self.assertEquals('<b>&amp;</b>', markup)
+        self.assertEqual('<b>&amp;</b>', markup)
 
     def test_mod_noescape(self):
         markup = Markup('<b>%(amp)s</b>') % {'amp': Markup('&amp;')}
         assert type(markup) is Markup
-        self.assertEquals('<b>&amp;</b>', markup)
+        self.assertEqual('<b>&amp;</b>', markup)
 
     def test_mul(self):
         markup = Markup('<b>foo</b>') * 2
         assert type(markup) is Markup
-        self.assertEquals('<b>foo</b><b>foo</b>', markup)
+        self.assertEqual('<b>foo</b><b>foo</b>', markup)
 
     def test_mul_reverse(self):
         markup = 2 * Markup('<b>foo</b>')
         assert type(markup) is Markup
-        self.assertEquals('<b>foo</b><b>foo</b>', markup)
+        self.assertEqual('<b>foo</b><b>foo</b>', markup)
 
     def test_join(self):
         markup = Markup('<br />').join(['foo', '<bar />', Markup('<baz />')])
         assert type(markup) is Markup
-        self.assertEquals('foo<br />&lt;bar /&gt;<br /><baz />', markup)
+        self.assertEqual('foo<br />&lt;bar /&gt;<br /><baz />', markup)
 
     def test_join_over_iter(self):
         items = ['foo', '<bar />', Markup('<baz />')]
         markup = Markup('<br />').join(i for i in items)
-        self.assertEquals('foo<br />&lt;bar /&gt;<br /><baz />', markup)
+        self.assertEqual('foo<br />&lt;bar /&gt;<br /><baz />', markup)
 
     def test_stripentities_all(self):
         markup = Markup('&amp; &#106;').stripentities()
         assert type(markup) is Markup
-        self.assertEquals('& j', markup)
+        self.assertEqual('& j', markup)
 
     def test_stripentities_keepxml(self):
         markup = Markup('&amp; &#106;').stripentities(keepxmlentities=True)
         assert type(markup) is Markup
-        self.assertEquals('&amp; j', markup)
+        self.assertEqual('&amp; j', markup)
 
     def test_striptags_empty(self):
         markup = Markup('<br />').striptags()
         assert type(markup) is Markup
-        self.assertEquals('', markup)
+        self.assertEqual('', markup)
 
     def test_striptags_mid(self):
         markup = Markup('<a href="#">fo<br />o</a>').striptags()
         assert type(markup) is Markup
-        self.assertEquals('foo', markup)
+        self.assertEqual('foo', markup)
 
     def test_pickle(self):
         markup = Markup('foo')
@@ -172,7 +172,7 @@ class MarkupTestCase(unittest.TestCase):
         pickle.dump(markup, buf, 2)
         buf.seek(0)
         expected_foo = "u'foo'" if IS_PYTHON2 else "'foo'"
-        self.assertEquals("<Markup %s>" % expected_foo, repr(pickle.load(buf)))
+        self.assertEqual("<Markup %s>" % expected_foo, repr(pickle.load(buf)))
 
 
 class AttrsTestCase(unittest.TestCase):
@@ -183,7 +183,7 @@ class AttrsTestCase(unittest.TestCase):
         pickle.dump(attrs, buf, 2)
         buf.seek(0)
         unpickled = pickle.load(buf)
-        self.assertEquals("Attrs([('attr1', 'foo'), ('attr2', 'bar')])",
+        self.assertEqual("Attrs([('attr1', 'foo'), ('attr2', 'bar')])",
                           repr(unpickled))
 
     def test_non_ascii(self):
@@ -211,9 +211,9 @@ class NamespaceTestCase(unittest.TestCase):
         pickle.dump(ns, buf, 2)
         buf.seek(0)
         unpickled = pickle.load(buf)
-        self.assertEquals("Namespace('http://www.example.org/namespace')",
+        self.assertEqual("Namespace('http://www.example.org/namespace')",
                           repr(unpickled))
-        self.assertEquals('http://www.example.org/namespace', unpickled.uri)
+        self.assertEqual('http://www.example.org/namespace', unpickled.uri)
 
 
 class QNameTestCase(unittest.TestCase):
@@ -224,10 +224,10 @@ class QNameTestCase(unittest.TestCase):
         pickle.dump(qname, buf, 2)
         buf.seek(0)
         unpickled = pickle.load(buf)
-        self.assertEquals('{http://www.example.org/namespace}elem', unpickled)
-        self.assertEquals('http://www.example.org/namespace',
+        self.assertEqual('{http://www.example.org/namespace}elem', unpickled)
+        self.assertEqual('http://www.example.org/namespace',
                           unpickled.namespace)
-        self.assertEquals('elem', unpickled.localname)
+        self.assertEqual('elem', unpickled.localname)
 
     def test_repr(self):
         self.assertEqual("QName('elem')", repr(QName('elem')))
@@ -244,8 +244,8 @@ class QNameTestCase(unittest.TestCase):
 
     def test_leading_curly_brace(self):
         qname = QName('{http://www.example.org/namespace}elem')
-        self.assertEquals('http://www.example.org/namespace', qname.namespace)
-        self.assertEquals('elem', qname.localname)
+        self.assertEqual('http://www.example.org/namespace', qname.namespace)
+        self.assertEqual('elem', qname.localname)
 
     def test_curly_brace_equality(self):
         qname1 = QName('{http://www.example.org/namespace}elem')


### PR DESCRIPTION
Replace `assertEquals` with `assertEqual`. `assertEquals` was deprecated in Python 3.2.

Addresses #41.