### PR TITLE
Do not use value and namespaces to sort directives

### DIFF
--- a/genshi/template/base.py
+++ b/genshi/template/base.py
@@ -489,7 +489,8 @@ class Template(DirectiveFactory):
             if kind is SUB:
                 directives = []
                 substream = data[1]
-                for _, cls, value, namespaces, pos in sorted(data[0]):
+                for _, cls, value, namespaces, pos in sorted(
+                        data[0], key=lambda x: x[0:1] + x[4:]):
                     directive, substream = cls.attach(self, substream, value,
                                                       namespaces, pos)
                     if directive:

--- a/genshi/template/base.py
+++ b/genshi/template/base.py
@@ -490,7 +490,7 @@ class Template(DirectiveFactory):
                 directives = []
                 substream = data[1]
                 for _, cls, value, namespaces, pos in sorted(
-                        data[0], key=lambda x: x[0:1] + x[4:]):
+                        data[0], key=lambda x: x[0]):
                     directive, substream = cls.attach(self, substream, value,
                                                       namespaces, pos)
                     if directive:

--- a/genshi/template/markup.py
+++ b/genshi/template/markup.py
@@ -148,7 +148,7 @@ class MarkupTemplate(Template):
                 new_attrs = Attrs(new_attrs)
 
                 if directives:
-                    directives.sort()
+                    directives.sort(key=lambda x: x[0])
                     dirmap[(depth, tag)] = (directives, len(new_stream),
                                             strip)
 

--- a/genshi/template/tests/markup.py
+++ b/genshi/template/tests/markup.py
@@ -23,6 +23,7 @@ import six
 
 from genshi.compat import BytesIO, StringIO
 from genshi.core import Markup
+from genshi.filters.i18n import Translator
 from genshi.input import XML
 from genshi.template.base import BadDirectiveError, TemplateSyntaxError
 from genshi.template.loader import TemplateLoader, TemplateNotFound
@@ -783,6 +784,19 @@ class MarkupTemplateTestCase(unittest.TestCase):
             <fourth type="blue">fish</fourth>
           </lines>
         </rhyme>""", tmpl.generate().render(encoding=None)) 
+
+    def test_directive_single_line_with_translator(self):
+        tmpl = MarkupTemplate("""<div xmlns:py="http://genshi.edgewall.org/">
+            <py:for each="i in range(2)"><py:for each="j in range(1)">
+                <span py:content="i + j"></span>
+            </py:for></py:for>
+        </div>""")
+        translator = Translator(lambda s: s)
+        tmpl.add_directives(Translator.NAMESPACE, translator)
+        self.assertEqual("""<div>
+                <span>0</span>
+                <span>1</span>
+        </div>""", str(tmpl.generate()))
 
 
 def suite():


### PR DESCRIPTION
The value and namespaces are dictionaries that can not be ordered.

The sorted was added in d48d93c09747c130e6e2ccd5ebefe23281c4e917