### PR TITLE
Fix reference leak in Markup.join C implementation

### DIFF
--- a/genshi/_speedups.c
+++ b/genshi/_speedups.c
@@ -372,6 +372,7 @@ Markup_join(PyObject *self, PyObject *args, PyObject *kwds)
     static char *kwlist[] = {"seq", "escape_quotes", 0};
     PyObject *seq = NULL, *seq2, *it, *tmp, *tmp2;
     char quotes = 1;
+    int ret;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|b", kwlist, &seq, &quotes)) {
         return NULL;
@@ -386,13 +387,19 @@ Markup_join(PyObject *self, PyObject *args, PyObject *kwds)
     }
     while ((tmp = PyIter_Next(it))) {
         tmp2 = escape(tmp, quotes);
+        Py_DECREF(tmp);
         if (tmp2 == NULL) {
             Py_DECREF(seq2);
             Py_DECREF(it);
             return NULL;
         }
-        PyList_Append(seq2, tmp2);
-        Py_DECREF(tmp);
+        ret = PyList_Append(seq2, tmp2);
+        Py_DECREF(tmp2);
+        if (ret != 0) {
+            Py_DECREF(seq2);
+            Py_DECREF(it);
+            return NULL;
+        }
     }
     Py_DECREF(it);
     if (PyErr_Occurred()) {


### PR DESCRIPTION
When support for iterator arguments was added to the Markup.join implementation in 99ad51d the temporary tuple was replaced by a temporary list and a switch was made from `PyTuple_SET_ITEM` (which steals a reference) to `PyList_Append` (which does not) without adding the necessary `Py_DECREF` for the added item.

This PR adds the necessary reference.

Thanks you @eug3nix for reporting the issue in #46 and helping debug it. Would you mind checking that this PR solves your original issue?