### PR TITLE
WIP: Fix get_code_params for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, '3.10-dev', pypy2, pypy3]
+        python-version: [2.7,  3.4, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10-dev', '3.11-dev', pypy2, pypy3]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,4 +19,3 @@ jobs:
     - name: Run test suite
       run: |
         python setup.py test
-

--- a/genshi/template/tests/eval.py
+++ b/genshi/template/tests/eval.py
@@ -44,6 +44,7 @@ class ExpressionTestCase(unittest.TestCase):
         buf.seek(0)
         unpickled = pickle.load(buf)
         assert unpickled.evaluate({}) is True
+        assert unpickled.code == expr.code
 
     def test_name_lookup(self):
         self.assertEqual('bar', Expression('foo').evaluate({'foo': 'bar'}))
@@ -552,6 +553,7 @@ class SuiteTestCase(unittest.TestCase):
         data = {}
         unpickled.execute(data)
         self.assertEqual(42, data['foo'])
+        assert unpickled.code == suite.code
 
     def test_internal_shadowing(self):
         # The context itself is stored in the global execution scope of a suite


### PR DESCRIPTION
In #43 and #37 it was reported that the arguments to `code(...)` have changed in Python 3.10. This affects the `build_code_chunk` and `get_code_params` functions in `genshi.compat`.  `build_code_chunk` was fixed in #49. This PR is intended to fix `get_code_params`.

WIP: Currently this PR only attempts to get the tests to fail.