### PR TITLE
add support for testing via GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: run
+
+on: [push]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, '3.10-dev', pypy2, pypy3]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Run test suite
+      run: |
+        python setup.py test
+


### PR DESCRIPTION
Just add a basic GitHub Actions spec so that we get some CI testing (see https://github.com/edgewall/genshi/pull/50#issuecomment-921788556 why Travis does not work anymore).

"actions/setup-python@v2" does not support Python 3.4/3.5 out of the box so I removed these versions from testing.

Also no deployment step right now. You might want to reset the edgewall password given a recent [Travis Security Bulletin](https://travis-ci.community/t/security-bulletin/12081).