### PR TITLE
tests: stop using deprecated TestCase method names

### DIFF
--- a/genshi/template/tests/eval.py
+++ b/genshi/template/tests/eval.py
@@ -896,12 +896,12 @@ assert f() == 42
                 self.attr = 'foo'
         obj = Something()
         Suite("del obj.attr").execute({'obj': obj})
-        self.failIf(hasattr(obj, 'attr'))
+        self.assertFalse(hasattr(obj, 'attr'))
 
     def test_delitem(self):
         d = {'k': 'foo'}
         Suite("del d['k']").execute({'d': d})
-        self.failIf('k' in d, repr(d))
+        self.assertFalse('k' in d, repr(d))
 
     def test_with_statement(self):
         fd, path = mkstemp()

--- a/genshi/template/tests/eval.py
+++ b/genshi/template/tests/eval.py
@@ -901,7 +901,7 @@ assert f() == 42
     def test_delitem(self):
         d = {'k': 'foo'}
         Suite("del d['k']").execute({'d': d})
-        self.assertFalse('k' in d, repr(d))
+        self.assertNotIn('k', d)
 
     def test_with_statement(self):
         fd, path = mkstemp()

--- a/genshi/tests/path.py
+++ b/genshi/tests/path.py
@@ -655,21 +655,21 @@ class PathTestCase(unittest.TestCase):
         return strategy_class.supports(path)
 
     def test_simple_strategy_support(self):
-        self.assert_(self._test_support(SimplePathStrategy, 'a/b'))
-        self.assert_(self._test_support(SimplePathStrategy, 'self::a/b'))
-        self.assert_(self._test_support(SimplePathStrategy, 'descendant::a/b'))
-        self.assert_(self._test_support(SimplePathStrategy,
+        self.assertTrue(self._test_support(SimplePathStrategy, 'a/b'))
+        self.assertTrue(self._test_support(SimplePathStrategy, 'self::a/b'))
+        self.assertTrue(self._test_support(SimplePathStrategy, 'descendant::a/b'))
+        self.assertTrue(self._test_support(SimplePathStrategy,
                          'descendant-or-self::a/b'))
-        self.assert_(self._test_support(SimplePathStrategy, '//a/b'))
-        self.assert_(self._test_support(SimplePathStrategy, 'a/@b'))
-        self.assert_(self._test_support(SimplePathStrategy, 'a/text()'))
+        self.assertTrue(self._test_support(SimplePathStrategy, '//a/b'))
+        self.assertTrue(self._test_support(SimplePathStrategy, 'a/@b'))
+        self.assertTrue(self._test_support(SimplePathStrategy, 'a/text()'))
 
         # a//b is a/descendant-or-self::node()/b
-        self.assert_(not self._test_support(SimplePathStrategy, 'a//b'))
-        self.assert_(not self._test_support(SimplePathStrategy, 'node()/@a'))
-        self.assert_(not self._test_support(SimplePathStrategy, '@a'))
-        self.assert_(not self._test_support(SimplePathStrategy, 'foo:bar'))
-        self.assert_(not self._test_support(SimplePathStrategy, 'a/@foo:bar'))
+        self.assertTrue(not self._test_support(SimplePathStrategy, 'a//b'))
+        self.assertTrue(not self._test_support(SimplePathStrategy, 'node()/@a'))
+        self.assertTrue(not self._test_support(SimplePathStrategy, '@a'))
+        self.assertTrue(not self._test_support(SimplePathStrategy, 'foo:bar'))
+        self.assertTrue(not self._test_support(SimplePathStrategy, 'a/@foo:bar'))
 
     def _test_strategies(self, input, path, output,
                          namespaces=None, variables=None):


### PR DESCRIPTION
".assert_()" and ".failIf()" were removed in Python 3.11