### PR TITLE
element.getchildren() was removed from stdlib

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,22 +1,21 @@
 name: run
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, '3.10', pypy2, pypy3]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", pypy2, pypy3]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Run test suite
-      run: |
-        python setup.py test
-
+      - name: Run test suite
+        run: |
+          python setup.py test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.egg-info
+build
+*.so
+__pycache__

--- a/genshi/input.py
+++ b/genshi/input.py
@@ -45,7 +45,7 @@ def ET(element):
     yield START, (tag_name, attrs), (None, -1, -1)
     if element.text:
         yield TEXT, element.text, (None, -1, -1)
-    for child in element.getchildren():
+    for child in element:
         for item in ET(child):
             yield item
     yield END, tag_name, (None, -1, -1)

--- a/genshi/tests/input.py
+++ b/genshi/tests/input.py
@@ -13,11 +13,11 @@
 
 import unittest
 
-from genshi.core import Attrs, Stream
-from genshi.input import XMLParser, HTMLParser, ParseError
+from genshi.core import Attrs, QName, Stream
+from genshi.input import XMLParser, HTMLParser, ParseError, ET
 from genshi.compat import StringIO, BytesIO
 from genshi.tests.test_utils import doctest_suite
-
+from xml.etree import ElementTree
 
 class XMLParserTestCase(unittest.TestCase):
 
@@ -278,6 +278,21 @@ bar</elem>'''
         self.assertEqual(1, len(events))
         self.assertEqual((Stream.TEXT, text), events[0][:2])
 
+    def test_convert_ElementTree_to_markup_stream(self):
+        tree = ElementTree.fromstring(
+            u'<div class="test_div">text<span>some more text</span></div>'
+        )
+        events = list(ET(tree))
+        self.assertEqual(6, len(events))
+        self.assertEqual(
+            (Stream.START, (QName("div"), Attrs([(QName("class"), "test_div")]))),
+            events[0][:2],
+        )
+        self.assertEqual((Stream.TEXT, "text"), events[1][:2])
+        self.assertEqual((Stream.START, (QName("span"), Attrs())), events[2][:2])
+        self.assertEqual((Stream.TEXT, "some more text"), events[3][:2])
+        self.assertEqual((Stream.END, QName("span")), events[4][:2])
+        self.assertEqual((Stream.END, QName("div")), events[5][:2])
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
The method was removed with version 3.9 of the standard library: https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren