### PR TITLE
remove deprecation warnings

### DIFF
--- a/genshi/filters/html.py
+++ b/genshi/filters/html.py
@@ -354,7 +354,7 @@ class HTMLSanitizer(object):
     # IE6 <http://openmya.hacker.jp/hasegawa/security/expression.txt>
     #     7) Particular bit of Unicode characters
     _URL_FINDITER = re.compile(
-        u'[Uu][Rr\u0280][Ll\u029F]\s*\(([^)]+)').finditer
+        u'[Uu][Rr\u0280][Ll\u029F]%s*\(([^)]+)' % (r'\s')).finditer
 
     def __call__(self, stream):
         """Apply the filter to the given stream.

--- a/genshi/filters/i18n.py
+++ b/genshi/filters/i18n.py
@@ -1116,7 +1116,7 @@ class MessageBuffer(object):
             if '[' in data or ']' in data:
                 # Quote [ and ] if it ain't us adding it, ie, if the user is
                 # using those chars in their templates, escape them
-                data = data.replace('[', '\[').replace(']', '\]')
+                data = data.replace('[', r'\[').replace(']', r'\]')
             self.string.append(data)
             self._add_event(self.stack[-1], (kind, data, pos))
         elif kind is EXPR:
@@ -1171,7 +1171,7 @@ class MessageBuffer(object):
                     yield self.values[part]
                 elif part:
                     yield (TEXT,
-                           part.replace('\[', '[').replace('\]', ']'),
+                           part.replace(r'\[', '[').replace(r'\]', ']'),
                            (None, -1, -1)
                     )
 

--- a/genshi/path.py
+++ b/genshi/path.py
@@ -660,7 +660,7 @@ class PathParser(object):
     _QUOTES = (("'", "'"), ('"', '"'))
     _TOKENS = ('::', ':', '..', '.', '//', '/', '[', ']', '()', '(', ')', '@',
                '=', '!=', '!', '|', ',', '>=', '>', '<=', '<', '$')
-    _tokenize = re.compile('("[^"]*")|(\'[^\']*\')|((?:\d+)?\.\d+)|(%s)|([^%s\s]+)|\s+' % (
+    _tokenize = re.compile(r'("[^"]*")|(\'[^\']*\')|((?:\d+)?\.\d+)|(%s)|([^%s\s]+)|\s+' % (
                            '|'.join([re.escape(t) for t in _TOKENS]),
                            ''.join([re.escape(t[0]) for t in _TOKENS]))).findall
 

--- a/genshi/template/interpolation.py
+++ b/genshi/template/interpolation.py
@@ -30,7 +30,7 @@ NAMESTART = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_'
 NAMECHARS = NAMESTART + '.0123456789'
 PREFIX = '$'
 
-token_re = re.compile('%s|%s(?s)' % (
+token_re = re.compile('(?s)%s|%s' % (
     r'[uU]?[rR]?("""|\'\'\')((?<!\\)\\\1|.)*?\1',
     PseudoToken
 ))


### PR DESCRIPTION
escape sequences are suppressed by creating regex strings, flags have to be at the beginning of regex: https://github.com/gboeing/osmnx/issues/285