### PR TITLE
Do not use deprecated Ellipsis and Str

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -37,7 +37,7 @@ jobs:
 
   build_generic_wheel:
     name: Build generic wheel (without speedups)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       # Build a wheel without speedups that can run on pure Python
       GENSHI_BUILD_SPEEDUP: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11-dev", pypy2, pypy3]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", pypy2, pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", pypy2, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", pypy2, pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/genshi/compat.py
+++ b/genshi/compat.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     import _ast as ast
 import sys
+import warnings
 from types import CodeType
 
 import six
@@ -137,13 +138,15 @@ else:
 
 # In Python 3.8, Str and Ellipsis was replaced by Constant
 
-try:
-    _ast_Ellipsis = ast.Ellipsis
-    _ast_Str = ast.Str
-    _ast_Str_value = lambda obj: obj.s
-except AttributeError:
-    _ast_Ellipsis = _ast_Str = ast.Constant
-    _ast_Str_value = lambda obj: obj.value
+with warnings.catch_warnings():
+    warnings.filterwarnings('error', category=DeprecationWarning)
+    try:
+        _ast_Ellipsis = ast.Ellipsis
+        _ast_Str = ast.Str
+        _ast_Str_value = lambda obj: obj.s
+    except (AttributeError, DeprecationWarning):
+        _ast_Ellipsis = _ast_Str = ast.Constant
+        _ast_Str_value = lambda obj: obj.value
 
 class _DummyASTItem(object):
     pass


### PR DESCRIPTION
Python raises a warning when accessing those deprecated ast classes.
It will be better to avoid the warning because this code is about dealing with such deprecation.
Also it prevents to run tests which import genshi with the option `-Werror`.