### PR TITLE
Add Python 3.12 to CI matrix and fix Python 3.12 support.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", pypy2, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", pypy2, pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install setuptools
+        run: |
+          pip install setuptools
+
       - name: Run test suite
         run: |
           python setup.py test

--- a/genshi/compat.py
+++ b/genshi/compat.py
@@ -142,7 +142,7 @@ with warnings.catch_warnings():
     warnings.filterwarnings('error', category=DeprecationWarning)
     try:
         _ast_Ellipsis = ast.Ellipsis
-        _ast_Ellipsis_value = lambda obj: ...
+        _ast_Ellipsis_value = lambda obj: Ellipsis
         _ast_Str = ast.Str
         _ast_Str_value = lambda obj: obj.s
     except (AttributeError, DeprecationWarning):

--- a/genshi/compat.py
+++ b/genshi/compat.py
@@ -142,10 +142,13 @@ with warnings.catch_warnings():
     warnings.filterwarnings('error', category=DeprecationWarning)
     try:
         _ast_Ellipsis = ast.Ellipsis
+        _ast_Ellipsis_value = lambda obj: ...
         _ast_Str = ast.Str
         _ast_Str_value = lambda obj: obj.s
     except (AttributeError, DeprecationWarning):
-        _ast_Ellipsis = _ast_Str = ast.Constant
+        _ast_Ellipsis = ast.Constant
+        _ast_Ellipsis_value = lambda obj: obj.value
+        _ast_Str = ast.Constant
         _ast_Str_value = lambda obj: obj.value
 
 class _DummyASTItem(object):

--- a/genshi/filters/tests/i18n.py
+++ b/genshi/filters/tests/i18n.py
@@ -2203,12 +2203,12 @@ class ContextDirectiveTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest_suite(Translator.__module__))
-    suite.addTest(unittest.makeSuite(TranslatorTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(MsgDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(ChooseDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(DomainDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(ExtractTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(ContextDirectiveTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TranslatorTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(MsgDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ChooseDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DomainDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ExtractTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ContextDirectiveTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/filters/tests/test_html.py
+++ b/genshi/filters/tests/test_html.py
@@ -614,8 +614,8 @@ class HTMLSanitizerTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest_suite(HTMLFormFiller.__module__))
-    suite.addTest(unittest.makeSuite(HTMLFormFillerTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(HTMLSanitizerTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(HTMLFormFillerTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(HTMLSanitizerTestCase))
     return suite
 
 

--- a/genshi/filters/tests/transform.py
+++ b/genshi/filters/tests/transform.py
@@ -1492,7 +1492,7 @@ def suite():
                  EmptyTest, RemoveTest, UnwrapText, WrapTest, FilterTest,
                  MapTest, SubstituteTest, RenameTest, ReplaceTest, BeforeTest,
                  AfterTest, PrependTest, AppendTest, AttrTest, CopyTest, CutTest):
-        suite.addTest(unittest.makeSuite(test, 'test'))
+        suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(test))
     suite.addTest(doctest_suite(
         genshi.filters.transform, optionflags=doctest.NORMALIZE_WHITESPACE,
         extraglobs={'HTML': HTML, 'tag': tag, 'Markup': Markup}))

--- a/genshi/template/astutil.py
+++ b/genshi/template/astutil.py
@@ -14,7 +14,7 @@
 """Support classes for generating code from abstract syntax trees."""
 
 from genshi.compat import ast as _ast, _ast_Constant, IS_PYTHON2, isstring, \
-                          _ast_Ellipsis
+                          _ast_Ellipsis, _ast_Ellipsis_value
 
 __docformat__ = 'restructuredtext en'
 
@@ -721,7 +721,10 @@ class ASTCodeGenerator(object):
         self.visit(node.value)
         self._write('[')
         def _process_slice(node):
-            if isinstance(node, _ast_Ellipsis):
+            if (
+                isinstance(node, _ast_Ellipsis)
+                and _ast_Ellipsis_value(node) == ...
+            ):
                 self._write('...')
             elif isinstance(node, _ast.Slice):
                 if getattr(node, 'lower', 'None'):

--- a/genshi/template/astutil.py
+++ b/genshi/template/astutil.py
@@ -723,7 +723,7 @@ class ASTCodeGenerator(object):
         def _process_slice(node):
             if (
                 isinstance(node, _ast_Ellipsis)
-                and _ast_Ellipsis_value(node) == ...
+                and _ast_Ellipsis_value(node) == Ellipsis
             ):
                 self._write('...')
             elif isinstance(node, _ast.Slice):

--- a/genshi/template/tests/base.py
+++ b/genshi/template/tests/base.py
@@ -35,7 +35,7 @@ class ContextTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(Template.__module__))
-    suite.addTest(unittest.makeSuite(ContextTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ContextTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/template/tests/directives.py
+++ b/genshi/template/tests/directives.py
@@ -1217,16 +1217,16 @@ class WithDirectiveTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(directives))
-    suite.addTest(unittest.makeSuite(AttrsDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(ChooseDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(DefDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(ForDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(IfDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(MatchDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(ContentDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(ReplaceDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(StripDirectiveTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(WithDirectiveTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(AttrsDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ChooseDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(DefDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ForDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(IfDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(MatchDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ContentDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ReplaceDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(StripDirectiveTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(WithDirectiveTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/template/tests/eval.py
+++ b/genshi/template/tests/eval.py
@@ -1037,8 +1037,8 @@ with open(path) as file1, open(path) as file2:
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(Expression.__module__))
-    suite.addTest(unittest.makeSuite(ExpressionTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(SuiteTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ExpressionTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(SuiteTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/template/tests/interpolation.py
+++ b/genshi/template/tests/interpolation.py
@@ -195,7 +195,7 @@ class InterpolateTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(interpolate.__module__))
-    suite.addTest(unittest.makeSuite(InterpolateTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(InterpolateTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/template/tests/loader.py
+++ b/genshi/template/tests/loader.py
@@ -522,7 +522,7 @@ class TemplateLoaderTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(TemplateLoader.__module__))
-    suite.addTest(unittest.makeSuite(TemplateLoaderTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TemplateLoaderTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/template/tests/markup.py
+++ b/genshi/template/tests/markup.py
@@ -802,7 +802,7 @@ class MarkupTemplateTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(MarkupTemplate.__module__))
-    suite.addTest(unittest.makeSuite(MarkupTemplateTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(MarkupTemplateTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/template/tests/plugin.py
+++ b/genshi/template/tests/plugin.py
@@ -256,8 +256,8 @@ bar
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(MarkupTemplateEnginePluginTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(TextTemplateEnginePluginTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(MarkupTemplateEnginePluginTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TextTemplateEnginePluginTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/template/tests/text.py
+++ b/genshi/template/tests/text.py
@@ -295,8 +295,8 @@ Included
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(NewTextTemplate.__module__))
-    suite.addTest(unittest.makeSuite(OldTextTemplateTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(NewTextTemplateTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(OldTextTemplateTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(NewTextTemplateTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/tests/builder.py
+++ b/genshi/tests/builder.py
@@ -67,7 +67,7 @@ class ElementFactoryTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest.DocTestSuite(Element.__module__))
-    suite.addTest(unittest.makeSuite(ElementFactoryTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ElementFactoryTestCase))
     return suite
 
 

--- a/genshi/tests/core.py
+++ b/genshi/tests/core.py
@@ -256,11 +256,11 @@ class QNameTestCase(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(StreamTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(MarkupTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(NamespaceTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(AttrsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(QNameTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(StreamTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(MarkupTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(NamespaceTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(AttrsTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(QNameTestCase))
     suite.addTest(doctest_suite(core))
     return suite
 

--- a/genshi/tests/input.py
+++ b/genshi/tests/input.py
@@ -297,8 +297,8 @@ bar</elem>'''
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest_suite(XMLParser.__module__))
-    suite.addTest(unittest.makeSuite(XMLParserTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(HTMLParserTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(XMLParserTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(HTMLParserTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/genshi/tests/output.py
+++ b/genshi/tests/output.py
@@ -469,10 +469,10 @@ class EmptyTagFilterTestCase(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(XMLSerializerTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(XHTMLSerializerTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(HTMLSerializerTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(EmptyTagFilterTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(XMLSerializerTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(XHTMLSerializerTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(HTMLSerializerTestCase))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(EmptyTagFilterTestCase))
     suite.addTest(doctest_suite(XMLSerializer.__module__))
     return suite
 

--- a/genshi/tests/path.py
+++ b/genshi/tests/path.py
@@ -709,7 +709,7 @@ class PathTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest_suite(Path.__module__))
-    suite.addTest(unittest.makeSuite(PathTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(PathTestCase))
     return suite
 
 

--- a/genshi/tests/util.py
+++ b/genshi/tests/util.py
@@ -87,7 +87,7 @@ class LRUCacheTestCase(unittest.TestCase):
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest_suite(util))
-    suite.addTest(unittest.makeSuite(LRUCacheTestCase, 'test'))
+    suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(LRUCacheTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,8 @@ packages =
     genshi.template.tests.templates
 install_requires =
     six
+setup_requires =
+    setuptools
 
 [options.entry_points]
 babel.extractors =


### PR DESCRIPTION
This PR:
* Adds Python 3.12 to the CI matrix.
* Applies Fedora's patch to use the default test loader (https://src.fedoraproject.org/rpms/python-genshi/blob/rawhide/f/python-genshi-use-default-test-loader.patch)
* Fixes the handling of ast.Ellipsis in Python 3.12 (this was broken by the recent warnings suppression change).