### PR TITLE
Fix HTMLParser error handling.

### DIFF
--- a/genshi/input.py
+++ b/genshi/input.py
@@ -347,7 +347,7 @@ class HTMLParser(html.HTMLParser, object):
                             yield END, QName(tag), pos
                         break
             except Exception as e:
-                # Python simple HTMLParser does not raise detailed
+                # Python's simple HTMLParser does not raise detailed
                 # errors except in strict mode which was deprecated
                 # in Python 3.3 and removed in Python 3.5 and which in
                 # any case is not used is this code.

--- a/genshi/input.py
+++ b/genshi/input.py
@@ -346,9 +346,13 @@ class HTMLParser(html.HTMLParser, object):
                         for tag in open_tags:
                             yield END, QName(tag), pos
                         break
-            except html.HTMLParseError as e:
-                msg = '%s: line %d, column %d' % (e.msg, e.lineno, e.offset)
-                raise ParseError(msg, self.filename, e.lineno, e.offset)
+            except Exception as e:
+                # Python simple HTMLParser does not raise detailed
+                # errors except in strict mode which was deprecated
+                # in Python 3.3 and removed in Python 3.5 and which in
+                # any case is not used is this code.
+                msg = str(e)
+                raise ParseError(msg, self.filename)
         return Stream(_generate()).filter(_coalesce)
 
     def __iter__(self):

--- a/genshi/tests/test_input.py
+++ b/genshi/tests/test_input.py
@@ -15,7 +15,7 @@ import unittest
 
 from genshi.core import Attrs, QName, Stream
 from genshi.input import XMLParser, HTMLParser, ParseError, ET
-from genshi.compat import StringIO, BytesIO
+from genshi.compat import IS_PYTHON2, StringIO, BytesIO
 from genshi.tests.utils import doctest_suite
 from xml.etree import ElementTree
 
@@ -297,12 +297,15 @@ bar</elem>'''
     def test_parsing_error(self):
         text = u'<div></div>'.encode('utf-8')
         events = HTMLParser(BytesIO(text))
-        self.assertRaisesRegex(
-            ParseError,
-            r"source returned bytes, but no encoding specified",
-            list,
-            events,
-        )
+        if IS_PYTHON2:
+            self.assertRaises(ParseError, list, events)
+        else:
+            self.assertRaisesRegex(
+                ParseError,
+                r"source returned bytes, but no encoding specified",
+                list,
+                events,
+            )
 
 
 def suite():

--- a/genshi/tests/test_input.py
+++ b/genshi/tests/test_input.py
@@ -294,6 +294,17 @@ bar</elem>'''
         self.assertEqual((Stream.END, QName("span")), events[4][:2])
         self.assertEqual((Stream.END, QName("div")), events[5][:2])
 
+    def test_parsing_error(self):
+        text = u'<div></div>'.encode('utf-8')
+        events = HTMLParser(BytesIO(text))
+        self.assertRaisesRegex(
+            ParseError,
+            r"source returned bytes, but no encoding specified",
+            list,
+            events,
+        )
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(doctest_suite(XMLParser.__module__))


### PR DESCRIPTION
Genshi's HTMLParser referenced Python's `html.HTMLParseError` exception type in its try except clause. This exception class was deprecated in Python 3.3, removed in Python 3.5, and was not raised except in strict mode which, as far as I can tell from the version history, Genshi never used.

See https://docs.python.org/3.4/library/html.parser.html#html.parser.HTMLParseError.

Fixes #85.