### PR TITLE
Fix deprecation warning when creating AST node without required fields

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,15 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "pypy3.9"]
-        pytest-extra-options: ["--strict-config"]
-        include:
-          - python-version: "pypy2.7"
-            pytest-extra-options: ""
-          - python-version: "pypy3.11"
-            pytest-extra-options: ""
-          - python-version: "3.13.0-beta.2"
-            pytest-extra-options: "--strict-config -W ignore::DeprecationWarning"
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
       fail-fast: false
 
     steps:
@@ -37,12 +29,8 @@ jobs:
 
       - name: Run test suite
         run: |
-          pytest -Werror --strict-markers --verbosity=1 --color=yes ${{ matrix.pytest-extra-options }} genshi
+          pytest --strict-markers --verbosity=1 --color=yes genshi
           # Above flags are:
-          #  -Werror
-          #     treat warnings as errors
-          #  --strict-config
-          #     error out if the configuration file is not parseable
           #  --strict-markers
           #     error out if a marker is used but not defined in the
           #     configuration file

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
       fail-fast: false
 
     steps:

--- a/genshi/template/astutil.py
+++ b/genshi/template/astutil.py
@@ -802,7 +802,7 @@ class ASTTransformer(object):
         return visitor(node)
 
     def _clone(self, node):
-        clone = node.__class__()
+        clone = construct_ast_class(node.__class__)
         for name in getattr(clone, '_attributes', ()):
             try:
                 setattr(clone, name, getattr(node, name))
@@ -887,3 +887,17 @@ class ASTTransformer(object):
     visit_Index = _clone
 
     del _clone
+
+
+def construct_ast_class(cls):
+    kwargs = {}
+    for name, typ in cls.__annotations__.items():
+        if typ is str:
+            kwargs[name] = 'foo'
+        elif typ is int:
+            kwargs[name] = 42
+        elif typ is object:
+            kwargs[name] = b'foo'
+        elif isinstance(typ, type) and issubclass(typ, _ast.AST):
+            kwargs[name] = construct_ast_class(typ)
+    return cls(**kwargs)

--- a/genshi/template/astutil.py
+++ b/genshi/template/astutil.py
@@ -891,13 +891,14 @@ class ASTTransformer(object):
 
 def construct_ast_class(cls):
     kwargs = {}
-    for name, typ in cls.__annotations__.items():
-        if typ is str:
-            kwargs[name] = 'foo'
-        elif typ is int:
-            kwargs[name] = 42
-        elif typ is object:
-            kwargs[name] = b'foo'
-        elif isinstance(typ, type) and issubclass(typ, _ast.AST):
-            kwargs[name] = construct_ast_class(typ)
+    if hasattr(cls, '__annotations__'):
+        for name, typ in cls.__annotations__.items():
+            if typ is str:
+                kwargs[name] = 'foo'
+            elif typ is int:
+                kwargs[name] = 42
+            elif typ is object:
+                kwargs[name] = b'foo'
+            elif isinstance(typ, type) and issubclass(typ, _ast.AST):
+                kwargs[name] = construct_ast_class(typ)
     return cls(**kwargs)

--- a/genshi/template/eval.py
+++ b/genshi/template/eval.py
@@ -18,7 +18,8 @@ from types import CodeType
 
 from genshi.compat import builtins, exec_, string_types, text_type
 from genshi.core import Markup
-from genshi.template.astutil import ASTTransformer, ASTCodeGenerator, parse
+from genshi.template.astutil import (
+    ASTTransformer, ASTCodeGenerator, parse, construct_ast_class)
 from genshi.template.base import TemplateRuntimeError
 from genshi.util import flatten
 
@@ -59,11 +60,9 @@ class Code(object):
                 'Expected string or AST node, but got %r' % source
             self.source = '?'
             if self.mode == 'eval':
-                node = _ast.Expression()
-                node.body = source
+                node = _ast.Expression(body=source)
             else:
-                node = _ast.Module()
-                node.body = [source]
+                node = _ast.Module(body=[source])
 
         self.ast = node
         self.code = _compile(node, self.source, mode=self.mode,
@@ -454,7 +453,7 @@ def _compile(node, source=None, mode='eval', filename=None, lineno=-1,
 
 
 def _new(class_, *args, **kwargs):
-    ret = class_()
+    ret = construct_ast_class(class_)
     for attr, value in zip(ret._fields, args):
         if attr in kwargs:
             raise ValueError('Field set both in args and kwargs')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 addopts = --doctest-modules
 doctest_optionflags = NORMALIZE_WHITESPACE ALLOW_UNICODE
+filterwarnings =
+    error
+    ignore:pkg_resources


### PR DESCRIPTION
Python 3.13 added the warning which will become an error in Python 3.15 (see https://github.com/python/cpython/pull/105880)