### PR TITLE
Port from pkg_resources to importlib.resources

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,14 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "pypy3.9"]
-        pytest-extra-options: ["--strict-config -W \"ignore:pkg_resources is deprecated\""]
+        pytest-extra-options: ["--strict-config"]
         include:
           - python-version: "pypy2.7"
             pytest-extra-options: ""
           - python-version: "pypy3.11"
             pytest-extra-options: ""
           - python-version: "3.13.0-beta.2"
-            pytest-extra-options: "--strict-config -W \"ignore:pkg_resources is deprecated\" -W ignore::DeprecationWarning"
+            pytest-extra-options: "--strict-config -W ignore::DeprecationWarning"
       fail-fast: false
 
     steps:

--- a/doc/loader.rst
+++ b/doc/loader.rst
@@ -154,8 +154,8 @@ That is the same as:
 ``package(name, path)``
 -----------------------
 
-Uses the ``pkg_resources`` API to locate files in Python package data (which
-may be inside a ZIP archive).
+Uses the ``importlib.resources`` API to locate files in Python package data
+(which may be inside a ZIP archive).
 
 .. code-block:: python
 

--- a/genshi/template/loader.py
+++ b/genshi/template/loader.py
@@ -13,6 +13,10 @@
 
 """Template loading and caching."""
 
+try:
+    from importlib.resources import open_binary as resources_open_binary
+except ImportError:
+    from importlib_resources import open_binary as resources_open_binary
 import os
 try:
     import threading
@@ -300,10 +304,14 @@ class TemplateLoader(object):
         :return: the loader function to load templates from the given package
         :rtype: ``function``
         """
-        from pkg_resources import resource_stream
         def _load_from_package(filename):
             filepath = os.path.join(path, filename)
-            return filepath, filename, resource_stream(name, filepath), None
+            return (
+                filepath,
+                filename,
+                resources_open_binary(name, filepath),
+                None,
+            )
         return _load_from_package
 
     @staticmethod

--- a/genshi/template/plugin.py
+++ b/genshi/template/plugin.py
@@ -16,6 +16,17 @@
 CherryPy/Buffet.
 """
 
+try:
+    from importlib.resources import (
+        as_file as resources_as_file,
+        files as resources_files,
+    )
+except ImportError:
+    from importlib_resources import (
+        as_file as resources_as_file,
+        files as resources_files,
+    )
+
 from genshi.compat import string_types
 from genshi.input import ET, HTML, XML
 from genshi.output import DocType
@@ -91,10 +102,11 @@ class AbstractTemplateEnginePlugin(object):
         if self.use_package_naming:
             divider = templatename.rfind('.')
             if divider >= 0:
-                from pkg_resources import resource_filename
                 package = templatename[:divider]
                 basename = templatename[divider + 1:] + self.extension
-                templatename = resource_filename(package, basename)
+                resource = resources_files(package) / basename
+                with resources_as_file(resource) as path:
+                    return self.loader.load(str(path))
 
         return self.loader.load(templatename)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ packages =
     genshi.template.tests.templates
 setup_requires =
     setuptools
+install_requires =
+    importlib-resources; python_version<"3.9"
 
 [options.entry_points]
 babel.extractors =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py27,py36,py37,py38,py39,py310,py311,py312,pypy,pypy3
 [testenv]
 deps=
-    setuptools
+    .
     pytest
 setenv=
     PYTHONHASHSEED=0


### PR DESCRIPTION
`pkg_resources` is deprecated (see
https://setuptools.pypa.io/en/latest/pkg_resources.html).