### PR TITLE
Several RTD build fixes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,7 @@ build:
 
 sphinx:
   configuration: doc/conf.py
+  fail_on_warning: true
 
 formats:
   - pdf

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,3 +20,5 @@ formats:
 python:
   install:
     - requirements: doc/requirements.txt
+    - method: pip
+      path: .

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,8 @@
 project = "Genshi"
 copyright = "2024, Edgewall Software"
 author = "Edgewall Software"
-release = "0.8"
+version = "0.8"
+release = version
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,7 +32,7 @@ autodoc_preserve_defaults = True
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
+html_static_path = []
 html_theme_options = {
     "collapse_navigation": True,
     "sticky_navigation": True,

--- a/doc/text-templates.rst
+++ b/doc/text-templates.rst
@@ -10,9 +10,9 @@ The language is similar to the Django_ template language.
 
 This document describes the template language and will be most useful as
 reference to those developing Genshi text templates. Templates are text files of
-some kind that include processing directives_ that affect how the template is
-rendered, and template expressions that are dynamically substituted by
-variable data.
+some kind that include processing `directives <tt-directives>`_ that affect
+how the template is rendered, and template expressions that are dynamically
+substituted by variable data.
 
 See `Genshi Templating Basics <templates.html>`_ for general information on
 embedding Python code in templates.
@@ -26,7 +26,7 @@ embedding Python code in templates.
 .. _django: http://www.djangoproject.com/
 
 
-.. _`directives`:
+.. _`tt-directives`:
 
 -------------------
 Template Directives
@@ -144,7 +144,7 @@ Snippet Reuse
 =============
 
 .. _`def`:
-.. _`macros`:
+.. _`tt-macros`:
 
 ``{% def %}``
 -------------
@@ -181,7 +181,7 @@ The above would be rendered to::
     Hello, world!
 
 
-.. _includes:
+.. _tt-includes:
 .. _`include`:
 
 ``{% include %}``
@@ -196,8 +196,8 @@ other files using the ``include`` directive:
 
 Any content included this way is inserted into the generated output. The
 included template sees the context data as it exists at the point of the
-include. `Macros`_ in the included template are also available to the including
-template after the point it was included.
+include. `Macros <tt-macros>`_ in the included template are also available to
+the including template after the point it was included.
 
 Include paths are relative to the filename of the template currently being
 processed. So if the example above was in the file "``myapp/mail.txt``"
@@ -222,7 +222,7 @@ be found.
 Variable Binding
 ================
 
-.. _`with`:
+.. _`tt-with`:
 
 ``{% with %}``
 --------------
@@ -290,7 +290,7 @@ moving the indentation into the delimiters, or moving the end delimiter on the
 next line, and so on.
 
 
-.. _comments:
+.. _tt-comments:
 
 --------
 Comments

--- a/doc/xml-templates.rst
+++ b/doc/xml-templates.rst
@@ -16,16 +16,16 @@ XSLT_, TAL_, and PHP_.
 
 This document describes the template language and will be most useful as
 reference to those developing Genshi XML templates. Templates are XML files of
-some kind (such as XHTML) that include processing directives_ (elements or
-attributes identified by a separate namespace) that affect how the template is
-rendered, and template expressions that are dynamically substituted by
-variable data.
+some kind (such as XHTML) that include processing `directives <xt-directives>`_
+(elements or attributes identified by a separate namespace) that affect how the
+template is rendered, and template expressions that are dynamically substituted
+by variable data.
 
 See `Genshi Templating Basics <templates.html>`_ for general information on
 embedding Python code in templates.
 
 
-.. _`directives`:
+.. _`xt-directives`:
 
 -------------------
 Template Directives
@@ -642,8 +642,8 @@ Dynamic Includes
 ================
 
 Incudes in Genshi are fully dynamic: Just like normal attributes, the `href`
-attribute accepts expressions, and directives_ can be used on the
-``<xi:include />`` element just as on any other element, meaning you can do
+attribute accepts expressions, and `directives <xt-directives>`_ can be used on
+the ``<xi:include />`` element just as on any other element, meaning you can do
 things like conditional includes:
 
 .. code-block:: html+genshi


### PR DESCRIPTION
The API docs were failing to build due to the classic RTD issue of [not installing the project](https://docs.readthedocs.com/platform/stable/tutorial/index.html#making-build-warnings-more-visible) itself. This PR is a series of commits fixing several issues:

1. Adds installing the project to `.readthedocs.yaml` to get the API docs building
2. Fixes a few duplicate labels in the docs and ...
3. Fixes a config warning (non-existing `_static` dir) so that...
4. We can make RTD fail on warnings
5. Fix up the last warning by setting "version" as well as "release" (to allow EPUB to build correctly)

I did a [test build](https://app.readthedocs.org/projects/genshi-test/builds/33768348/) (okay, several) on RTD to check the build works with this configuration, and to make sure the API docs now appear. The build output is [here](https://genshi-test.readthedocs.io/en/docs-fix/)